### PR TITLE
Add missing passthrough of tx_ordinal

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -295,11 +295,9 @@ const txBodies: HandlerFunction = async function (req, _res) {
 
 const history: HandlerFunction = async function (req, _res) {
   const input: HistoryInput = req.body;
-  console.log(input);
 
   if(!req.body) {
     const errMsg = "error, no body";
-    console.log(errMsg);
     return { status: 400, body: errMsg}
   }
   const verifiedBody = utils.validateHistoryReq(addressesRequestLimit, apiResponseLimit, input);
@@ -337,6 +335,7 @@ const history: HandlerFunction = async function (req, _res) {
           hash: tx.id,
           tx_state: 'Successful', // explorer doesn't handle pending transactions
           block_num: tx.inclusionHeight,
+          tx_ordinal: tx.index,
           block_hash: tx.headerId,
           time: iso8601date,
           epoch: 0, // TODO
@@ -350,7 +349,6 @@ const history: HandlerFunction = async function (req, _res) {
       return { status: 200, body: txs };
     }
     case "error": {
-      console.log(verifiedBody.errMsg);
       return { status: 400, body: verifiedBody.errMsg };
     }
     default: return utils.assertNever(verifiedBody);

--- a/src/types/explorer.js
+++ b/src/types/explorer.js
@@ -107,6 +107,7 @@ export type getApiV0AddressesP1TransactionsItem = {
   "id": string,
   "headerId": string,
   "inclusionHeight": number,
+  "index": number,
   "timestamp": number,
   "confirmationsCount": number,
   "inputs": Array<{

--- a/test/test.js
+++ b/test/test.js
@@ -120,6 +120,7 @@ const specs: Array<Spec> = [
     output: [{
       "block_hash": "a4e7c126bb3f26384efff11157b24fc09020f56bc782ad5b821097eeb6165dc1",
       "block_num": 277204,
+      "tx_ordinal": 1,
       "epoch": 0,
       "hash": "c8df2f2d0dca51ab9a375ad9c77322cc11ebd7f3ba088168797e06371a573818",
       "inputs": [{


### PR DESCRIPTION
When I made https://github.com/Emurgo/yoroi-ergo-backend/pull/10 I forgot to passthrough the tx_ordinal 