### PR TITLE
Add more info about asset box

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,10 @@ This is a wrapper for the [Ergo explorer API](https://explorer.ergoplatform.com/
     [assetId: string]: {
       name: null | string,
       desc: null | string,
-      numDecimals: null | string,
+      numDecimals: null | number,
+      // information about box that defined the metadata for this token
+      height: null | number,
+      boxId: string,
     }
   }
   ```

--- a/src/api.js
+++ b/src/api.js
@@ -174,8 +174,13 @@ const askPendingTransaction = async (
  * try parsing an int (base 10) and return NaN if it fails
  * Can't use parseInt because parseInt('1a') returns '1' instead of failing
  */
-function intOrNaN (x) {
+function hexToIntOrNaN(x: string) {
   return /^[0-9a-fA-F]+$/.test(x) ? Number.parseInt(x, 16) : NaN
+}
+
+function numDecimalsToNum(x: string | null): number | null {
+  if (x == null) return x;
+  return /^[0-9]+$/.test(x) ? Number.parseInt(x, 10) : null
 }
 
 const askAssetInfo = async (
@@ -200,7 +205,7 @@ const askAssetInfo = async (
     // recall: every encoding start with 0e then one byte for length
     if (field.length < 3 * 2) return null; // minimum 3 bytes: 1 for prefix, 1 for length, 1 for content
 
-    const expectedSize = intOrNaN(field.substring(2, 4));
+    const expectedSize = hexToIntOrNaN(field.substring(2, 4));
     if (isNaN(expectedSize)) return null;
     const content = field.substring('0eff'.length);
     if (content.length != 2 * expectedSize) return null;
@@ -218,7 +223,9 @@ const askAssetInfo = async (
       {
         name: decode(box.additionalRegisters['R4']),
         desc: decode(box.additionalRegisters['R5']),
-        numDecimals: decode(box.additionalRegisters['R6']),
+        numDecimals: numDecimalsToNum(decode(box.additionalRegisters['R6'])),
+        boxId: box.id,
+        height: box.creationHeight,
       },
     ],
   };

--- a/src/types/wrapperApi.js
+++ b/src/types/wrapperApi.js
@@ -105,7 +105,10 @@ export type AssetInfoInput = {|
 export type AssetInfo = {|
   name: null | string,
   desc: null | string,
-  numDecimals: null | string,
+  numDecimals: null | number,
+  // information about box that defined the metadata for this token
+  height: null | number,
+  boxId: string,
 |};
 export type AssetInfoOut = {|
   [assetId: string]: AssetInfo

--- a/test/real.test.js
+++ b/test/real.test.js
@@ -119,16 +119,22 @@ const specs: Array<Spec> = [
         name: null,
         desc: null,
         numDecimals: null,
+        boxId: 'a91a141904823b5aea0b33458a435d0ef3ab15975ca2b6afd07d43fd8bca9476',
+        height: 345903,
       });
       expect(output['82ebfb6141fbf31bd4a131017af86e24b5c367b17b3a30b3828bd419cf302dc9']).toEqual({
         name: 'Coinbarn',
         desc: 'test token of coinbarn.app',
-        numDecimals: '3',
+        numDecimals: 3,
+        boxId: '02030bb1e88597b28e88e807d8308cddde7291527e194fc44b5137fe7452f255',
+        height: 98787,
       });
       expect(output['3ff9fdfcda75531d1b5933d016a128bacf92e33817ba9441a4838ba3f247da31']).toEqual({
         name: '.;.',
         desc: `';`,
         numDecimals: null,
+        boxId: '24052b29cb831d87ac8407e7f4af1851e4763e119ac97dd1de6332411279ecd7',
+        height: 267222,
       });
     },
   },


### PR DESCRIPTION
This adds the `boxId` and the `creationHeight` of the box that created the asset. We need this to detect rollbacks that may affect token definitions.