### PR TITLE
Fix pagination again

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -81,7 +81,7 @@ const askInChainTransaction = async (
     if (r.items.length < limit) {
       return { items: newAcc };
     }
-    return await pagination(addr, acc, limit, offset + limit);
+    return await pagination(addr, newAcc, limit, offset + limit);
   }
 
   const inChainResponses = await Promise.all(addresses.map((address) => (
@@ -353,7 +353,7 @@ async function getUtxoForAddress(address: string): Promise<UtilEither<UtxoForAdd
     if (r.items.length < limit) {
       return { items: newAcc };
     }
-    return await pagination(addr, acc, limit, offset + limit);
+    return await pagination(addr, newAcc, limit, offset + limit);
   }
   
   const paginatedResponse = await pagination(address, [], apiResponseLimit, 0);

--- a/test/real.test.js
+++ b/test/real.test.js
@@ -226,6 +226,19 @@ const specs: Array<Spec> = [
   },
 
   {
+    name: 'history',
+    method: 'post',
+    endpoint: '/api/v2/txs/history',
+    input: {
+      addresses: ['9en2JxyCnQgjgRCaFMXBX87z1VcGjVvd3yug2GVmJXRHw59Evgz'],
+      untilBlock: '5aa15b0eb56ca3c4feab2fc99c53eef6f7fbf4beefa8a0e1bc76e7bd72118a0a',
+    },
+    output: (output) => {
+      expect(output.length).toBe(103);
+    }
+  },
+
+  {
     method: 'get',
     endpoint: '/api/status',
     output: { isServerOk: true },


### PR DESCRIPTION
The pagination has a bug making it only return the last page

ex: if you have 103 txs, there are three pages: [50, 50, 3]. The bug made it only return the last 3