### PR TITLE
Fix big values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5278,6 +5278,11 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-bigint-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json-bigint-native/-/json-bigint-native-1.1.0.tgz",
+      "integrity": "sha512-PPL9AlDP0ift5v8siEsR7oQsamOAIOLjn14GRaijZRUWDXsJC5rHXNlmtLPkPjK0k2i5yHK30VPqiFTZHolXaA=="
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bignumber.js": "9.0.0",
     "bunyan": "^1.8.14",
     "config": "^3.3.1",
+    "json-bigint-native": "1.1.0",
     "json-stable-stringify": "^1.0.1",
     "node-fetch": "^2.6.1",
     "restify": "^8.5.1",

--- a/src/api.js
+++ b/src/api.js
@@ -76,7 +76,7 @@ const askInChainTransaction = async (
       `${config.backend.explorer}/api/v0/addresses/${addr}/transactions?limit=${limit}&offset=${offset}`
     );
     if (resp.status !== 200) return { errMsg: `error querying transactions for address` };
-    const r: getApiV0AddressesP1TransactionsSuccessResponse = await resp.json();
+    const r: getApiV0AddressesP1TransactionsSuccessResponse = JSONBigInt.parse(await resp.text());
 
     const newAcc = [
       ...acc,
@@ -175,7 +175,7 @@ const askPendingTransaction = async (
   const unfilteredResponses: Array<getApiV0TransactionsUnconfirmedByaddressP1Item> = [];
   for (const response of pendingResponses) {
     if (response.status !== 200) return {kind:'error', errMsg: `error querying pending transactions for address`};
-    const json: getApiV0TransactionsUnconfirmedByaddressP1SuccessResponse = await response.json();
+    const json: getApiV0TransactionsUnconfirmedByaddressP1SuccessResponse = JSONBigInt.parse(await response.text());
 
     for (const item of json.items) {
       if (seenTransactions.has(item.id)) continue;

--- a/src/api.js
+++ b/src/api.js
@@ -3,6 +3,7 @@ const config = require('config');
 const fetch = require('node-fetch');
 const utils = require('./utils');
 const BigNumber = require('bignumber.js');
+const JSONBigInt = require('json-bigint-native');
 
 import type {
   UtxoForAddressesInput,
@@ -36,6 +37,9 @@ import type {
 
 const addressesRequestLimit = 50;
 const apiResponseLimit = 50;
+
+const asValue = (x: *): string =>
+  typeof x === 'bigint' ? x.toString() : String(x);
 
 const askBlockNum = async (blockHash: ?string, txHash?: string): Promise<UtilEither<number>> => {
   if (blockHash == undefined) return {kind:'ok', value: -1};
@@ -480,7 +484,7 @@ async function getTxBody(txHash: string): Promise<UtilEither<[string, getApiV0Tr
     return { kind: 'error', errMsg: `error getting tx body`};
   }
 
-  const txBody: getApiV0TransactionsP1SuccessResponse = await resp.json();
+  const txBody: getApiV0TransactionsP1SuccessResponse = JSONBigInt.parse(await resp.text());
   return {
     kind: 'ok',
     value: [ txHash, txBody ],

--- a/src/api.js
+++ b/src/api.js
@@ -338,7 +338,7 @@ const signed: HandlerFunction = async function (req, _res) {
   if (resp.status !== 200) {
     return { status: 400, body: `error sending transaction`};
   }
-  const r: postApiV0TransactionsSendSuccessResponse = await resp.json();
+  const r: postApiV0TransactionsSendSuccessResponse = JSONBigInt.parse(await resp.text());
   return { status: 200, body: r };
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const restify = require('restify');
 const config = require('config');
 const bunyan = require('bunyan');
 const corsMiddleware = require('restify-cors-middleware');
+const JSONBigInt = require('json-bigint-native');
 const api = require('./api');
 import type { HandlerDefinitions } from './types/utils';
 
@@ -44,7 +45,8 @@ function installHandlers(handlers: HandlerDefinitions) {
         // return int status === 0.
         if (status !== 0) {
           res.status(status);
-          res.json(body);
+          res.header('content-type', 'application/json');
+          res.sendRaw(JSONBigInt.stringify(body));
         }
       } catch (error) {
         req.log.error('handler error', error);

--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,12 @@ function installHandlers(handlers: HandlerDefinitions) {
         // return int status === 0.
         if (status !== 0) {
           res.status(status);
-          res.header('content-type', 'application/json');
-          res.sendRaw(JSONBigInt.stringify(body));
+          if (status === 200) {
+            res.header('content-type', 'application/json');
+            res.sendRaw(JSONBigInt.stringify(body));
+          } else {
+            res.json(body);
+          }
         }
       } catch (error) {
         req.log.error('handler error', error);


### PR DESCRIPTION
Added library `json-bigint`, because explorer sends JSON-encoded numbers up to i64, so we cannot parse them into regular JS i53 numbers.

Updated the internals in such a way that the API of the backend itself did not change - JSON response still contains numbers, but they are not lossy now, so the Yoroi compatibility will not break, but the Yoroi will not be lossy in all places where the backend responses are read with regular numbers - not having any breaking type changes (like wrapping into string) will allow now to safely deploy this and then update the Yoroi separately.