### PR TITLE
chore(src/api): do not use the existenial operator

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -327,10 +327,10 @@ const bestBlock: HandlerFunction = async function (_req, _res) {
 function fixTxValuesToBigInt(tx: postApiV0TransactionsSendRequest) {
   // Output value and asset amounts can be received as a number, string, or BigNumber
   // So we convert any value to BigNumber to make sure we are sending only JSON-numbers to the explorer API
-  if (tx.outputs !== undefined) {
+  if (tx.outputs != null) {
     tx.outputs.forEach(o => {
       o.value = new BigNumber(o.value);
-      if (o.assets !== undefined) {
+      if (o.assets != null) {
         o.assets.forEach(a => {
           a.amount = new BigNumber(a.amount);
         });

--- a/src/api.js
+++ b/src/api.js
@@ -327,12 +327,16 @@ const bestBlock: HandlerFunction = async function (_req, _res) {
 function fixTxValuesToBigInt(tx: postApiV0TransactionsSendRequest) {
   // Output value and asset amounts can be received as a number, string, or BigNumber
   // So we convert any value to BigNumber to make sure we are sending only JSON-numbers to the explorer API
-  tx.outputs?.forEach(o => {
-    o.value = new BigNumber(o.value);
-    o.assets?.forEach(a => {
-      a.amount = new BigNumber(a.amount);
+  if (tx.outputs !== undefined) {
+    tx.outputs.forEach(o => {
+      o.value = new BigNumber(o.value);
+      if (o.assets !== undefined) {
+        o.assets.forEach(a => {
+          a.amount = new BigNumber(a.amount);
+        });
+      }
     });
-  });
+  }
 }
 
 const signed: HandlerFunction = async function (req, _res) {


### PR DESCRIPTION
I think this is used in Typescript only.

```
yoroi-ergo-backend/flow-removed/api.js:297
  tx.outputs?.forEach(o => {
             ^
SyntaxError: Unexpected token '.'
```