### PR TITLE
Add token balances to utxo sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,13 @@ This is a wrapper for the [Ergo explorer API](https://explorer.ergoplatform.com/
     addresses: Array<string>,
   }
   ```
-  Output (note that `sum` and `totalNanoErgs` returns the **same value**. `sum` is a legacy property included in this response for backwards compatibility, but any new systems using this API should be using `totalNanoErgs` instead of `sum`):
+  Output:
   ```
   {
     sum: string,
-    totalNanoErgs: string,
     tokensBalance: [
-      tokenId: string,
-      amount: number,
+      assetId: string,
+      amount: string,
       decimals: number,
       name: string
     ]

--- a/README.md
+++ b/README.md
@@ -51,10 +51,17 @@ This is a wrapper for the [Ergo explorer API](https://explorer.ergoplatform.com/
     addresses: Array<string>,
   }
   ```
-  Output:
+  Output (note that `sum` and `totalNanoErgs` returns the **same value**. `sum` is a legacy property included in this response for backwards compatibility, but any new systems using this API should be using `totalNanoErgs` instead of `sum`):
   ```
   {
     sum: string,
+    totalNanoErgs: string,
+    tokensBalance: [
+      tokenId: string,
+      amount: number,
+      decimals: number,
+      name: string
+    ]
   }
   ```
 </details>

--- a/src/api.js
+++ b/src/api.js
@@ -498,7 +498,14 @@ const utxoSumForAddresses: HandlerFunction = async function (req, _res) {
 
   aggregate.tokensBalance = aggregateTokenBalances;
 
-  return { status: 200, body: aggregate };
+  return {
+    status: 200,
+    body: {
+      sum: aggregate.totalNanoErgs,
+      totalNanoErgs: aggregate.totalNanoErgs,
+      tokensBalance: aggregate.tokensBalance
+    }
+  };
 }
 
 async function isUsed(address: string): Promise<UtilEither<{| used: boolean, address: string |}>> {

--- a/src/api.js
+++ b/src/api.js
@@ -9,7 +9,6 @@ import type {
   UtxoForAddressesInput,
   UtxoForAddressesOutput,
   UtxoSumForAddressesInput,
-  UtxoSumForAddressesOutput,
   FilterUsedInput,
   FilterUsedOutput,
   TxBodiesInput,
@@ -39,9 +38,6 @@ import type {
 
 const addressesRequestLimit = 50;
 const apiResponseLimit = 50;
-
-const isNumberOrBigint = (x: *): boolean =>
-  (typeof x === 'number') || BigNumber.isBigNumber(x);
 
 const askBlockNum = async (blockHash: ?string, txHash?: string): Promise<UtilEither<number>> => {
   if (blockHash == undefined) return {kind:'ok', value: -1};

--- a/src/api.js
+++ b/src/api.js
@@ -453,23 +453,6 @@ async function getBalanceForAddress(address: string): Promise<UtilEither<Address
       }
     }
   }
-  
-
-  // const resp = await fetch(
-  //   `${config.backend.explorer}/api/v0/addresses/${address}`
-  // );
-  // if (resp.status !== 200) return {kind:'error', errMsg: `error querying utxos for address`};
-  // const r: getApiV0AddressesP1SuccessResponse = JSONBigInt.parse(await resp.text());
-  // if (r.transactions && isNumberOrBigint(r.transactions.confirmedBalance)) {
-  //   return {
-  //     kind: 'ok',
-  //     value: r.transactions.confirmedBalance,
-  //   };
-  // }
-  // return {
-  //   kind: 'ok',
-  //   value: 0,
-  // };
 }
 
 const utxoSumForAddresses: HandlerFunction = async function (req, _res) {

--- a/src/types/explorer.js
+++ b/src/types/explorer.js
@@ -291,6 +291,23 @@ export type getApiV0InfoSuccessResponse = {
 };
 export type getApiV0InfoResponse = getApiV0InfoSuccessResponse | FailResponse;
 
+export type getApiV1AddressesP1BalanceTotalResponse = {
+  confirmed: getApiV1AddressesP1BalanceTotalResponseItem,
+  unconfirmed: getApiV1AddressesP1BalanceTotalResponseItem
+}
+
+type getApiV1AddressesP1BalanceTotalResponseItem = {
+  nanoErgs: string,
+  tokens: $ReadOnlyArray<getApiV1AddressesP1BalanceTotalResponseItemToken>
+}
+
+type getApiV1AddressesP1BalanceTotalResponseItemToken = {
+  tokenId: string,
+  amount: string,
+  decimals: number,
+  name: string
+}
+
 // taken from the node API's swagger definition
 export type postApiV0TransactionsSendRequest = {|
   id?: string, // hex

--- a/src/types/wrapperApi.js
+++ b/src/types/wrapperApi.js
@@ -113,3 +113,13 @@ export type AssetInfo = {|
 export type AssetInfoOut = {|
   [assetId: string]: AssetInfo
 |};
+
+export type AddressBalanceResponse = {
+  totalNanoErgs: string,
+  tokensBalance: $ReadOnlyArray<{
+    tokenId: string,
+    amount: string,
+    decimals: number,
+    name: string
+  }>
+}

--- a/test/real.test.js
+++ b/test/real.test.js
@@ -42,20 +42,20 @@ const specs: Array<Spec> = [
     method: 'post',
     endpoint: '/api/txs/utxoSumForAddresses',
     input: { addresses: [] },
-    output: { sum: '0' },
+    output: { sum: '0', tokensBalance: [] },
   },
   {
     name: 'zero utxoSumForAddresses',
     method: 'post',
     endpoint: '/api/txs/utxoSumForAddresses',
     input: { addresses: ['9fzq1eba7sbiVYwtAV3GNufZEveKQsBPReX8Tmb9jtXjRJkttB7', '9ekxEAKApantTt1S6QTzAi9nypppCE2ovzT6ktVuCUvArdStYWC'] },
-    output: { sum: '0' },
+    output: { sum: '0', tokensBalance: [] },
   },
   {
     method: 'post',
     endpoint: '/api/txs/utxoSumForAddresses',
     input: { addresses: ['9fzq1eba7sbiVYwtAV3GNufZEveKQsBPReX8Tmb9jtXjRJkttB7', '9gEcxPe4ztVEhk97tU9iU632juQxMwfht4kZ37xbWF2tdLqpcDk'] },
-    output: { sum: '100000000' },
+    output: { sum: '100000000', tokensBalance: [] },
   },
 
   {


### PR DESCRIPTION
# Abstract
This PR intends to add the total token balances to the `/api/txs/utxoSumForAddresses`.

# Background
On Ergo Platform API `v0` we were using an endpoint which returns all transactions for the addresses to then sum the values of the UTxOs. In `v1` Ergo Platform adds a new endpoint which already returns the summed UTxOs ([getApiV1AddressesP1BalanceTotal](https://api.ergoplatform.com/api/v1/docs/#operation/getApiV1AddressesP1BalanceTotal)), so there's no need for us to do this calculation on our end anymore.

# Implementation
The implementation consists of changing the `getBalanceForAddress` to use the `getApiV1AddressesP1BalanceTotal` endpoint from Ergo Platform `v1`, which also includes the balances for the tokens. We then simply change the `utxoSumForAddresses` function to use the new data format returned by `getBalanceForAddress`.

The expected argument for this endpoint is an array of addresses and the previous implementation was was summing up the total ERG for all addresses. This behavior is being kept in the current implementation, taking into consideration the total balances for the tokens as well.

The new response includes the total ERG balance in a new field named `totalNanoErgs`, as well as in the old `sum` field for backward compatibility