### PR TITLE
Decrease API response limit to 20

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -36,7 +36,7 @@ import type {
 } from './types/explorer';
 
 const addressesRequestLimit = 50;
-const apiResponseLimit = 50;
+const apiResponseLimit = 20;
 
 const isNumberOrBigint = (x: *): boolean =>
   (typeof x === 'number') || BigNumber.isBigNumber(x);


### PR DESCRIPTION
This is a temporary solution in order to quick fix the issue related at Emurgo/yoroi-frontend#2461 as the fix in the back-end is being done.